### PR TITLE
Add check for older Bootloader version

### DIFF
--- a/custom_components/ckw_hass_gs108e/gs108e/__init__.py
+++ b/custom_components/ckw_hass_gs108e/gs108e/__init__.py
@@ -119,7 +119,7 @@ class GS108Switch(object):
                 new_lst.extend([0] * diff)
             return new_lst
 
-        if self._switch_bootloader in ['V2.06.03']:
+        if self._switch_bootloader in ['V2.06.01'] or self._switch_bootloader in ['V2.06.03']:
             rx_elems = tree.xpath('//input[@name="rxPkt"]')
             tx_elems = tree.xpath('//input[@name="txpkt"]')
             crc_elems = tree.xpath('//input[@name="crcPkt"]')


### PR DESCRIPTION
I have a Neatgear GS108Ev3 with
Bootloader: `V2.06.01`
Firmware: `V2.06.24EN`

The check for port stats would not be retrieved, so I added an additional Bootloader version to check for.