### PR TITLE
fix: re-login on expired session for PoE and LED switch commands

### DIFF
--- a/custom_components/netgear_plus/netgear_entities.py
+++ b/custom_components/netgear_plus/netgear_entities.py
@@ -518,7 +518,7 @@ class NetgearLedSwitchEntity(NetgearAPICoordinatorEntity, SwitchEntity):
         )
 
     async def async_turn_off(self, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
-        """Disable power on PoE port."""
+        """Disable front panel LEDs."""
         successful = await self.hub.async_call_api(self.hub.api.turn_off_leds)
         self._value = "off" if successful else "on"
         _LOGGER.info(

--- a/custom_components/netgear_plus/netgear_entities.py
+++ b/custom_components/netgear_plus/netgear_entities.py
@@ -254,7 +254,7 @@ unique_id={self._unique_id} port_nr={self.port_nr}>"
     async def async_turn_on(self, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         """Enable power on PoE port."""
         if self.port_nr:
-            successful = await self.hub.hass.async_add_executor_job(
+            successful = await self.hub.async_call_api(
                 self.hub.api.turn_on_poe_port, self.port_nr
             )
             self._value = "on" if successful else "off"
@@ -268,7 +268,7 @@ unique_id={self._unique_id} port_nr={self.port_nr}>"
     async def async_turn_off(self, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         """Disable power on PoE port."""
         if self.port_nr:
-            successful = await self.hub.hass.async_add_executor_job(
+            successful = await self.hub.async_call_api(
                 self.hub.api.turn_off_poe_port, self.port_nr
             )
             self._value = "off" if successful else "on"
@@ -509,9 +509,7 @@ class NetgearLedSwitchEntity(NetgearAPICoordinatorEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         """Enable front panel LEDs."""
-        successful = await self.hub.hass.async_add_executor_job(
-            self.hub.api.turn_on_leds
-        )
+        successful = await self.hub.async_call_api(self.hub.api.turn_on_leds)
         self._value = "on" if successful else "off"
         _LOGGER.info(
             "called turn_on_leds for uid=%s: successful=%s",
@@ -521,9 +519,7 @@ class NetgearLedSwitchEntity(NetgearAPICoordinatorEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: dict[str, Any]) -> None:  # noqa: ARG002
         """Disable power on PoE port."""
-        successful = await self.hub.hass.async_add_executor_job(
-            self.hub.api.turn_off_leds
-        )
+        successful = await self.hub.async_call_api(self.hub.api.turn_off_leds)
         self._value = "off" if successful else "on"
         _LOGGER.info(
             "called turn_off_leds for uid=%s: successful=%s",

--- a/custom_components/netgear_plus/netgear_switch.py
+++ b/custom_components/netgear_plus/netgear_switch.py
@@ -92,6 +92,27 @@ class HomeAssistantNetgearSwitch:
         async with self.api_lock:
             return await self.hass.async_add_executor_job(self.api.get_switch_infos)  # type: ignore[attr-defined]
 
+    async def async_call_api(self, func, *args) -> bool:
+        """Call an API write function under the lock, re-logging in once if the session expired."""
+        async with self.api_lock:
+            result = await self.hass.async_add_executor_job(func, *args)
+            if not result:
+                _LOGGER.info(
+                    "API call %s returned False, session likely expired — attempting re-login",
+                    func.__name__,
+                )
+                relogged = await self.hass.async_add_executor_job(
+                    self.api.get_login_cookie
+                )
+                if relogged:
+                    _LOGGER.info("Re-login successful, retrying %s", func.__name__)
+                    result = await self.hass.async_add_executor_job(func, *args)
+                else:
+                    _LOGGER.warning(
+                        "Re-login failed, cannot complete API call %s", func.__name__
+                    )
+            return result
+
 
 class NetgearCoordinatorEntity(CoordinatorEntity):
     """Base class for a Netgear router entity."""

--- a/custom_components/netgear_plus/netgear_switch.py
+++ b/custom_components/netgear_plus/netgear_switch.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 from abc import abstractmethod
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant, callback

--- a/custom_components/netgear_plus/netgear_switch.py
+++ b/custom_components/netgear_plus/netgear_switch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from abc import abstractmethod
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -92,13 +93,13 @@ class HomeAssistantNetgearSwitch:
         async with self.api_lock:
             return await self.hass.async_add_executor_job(self.api.get_switch_infos)  # type: ignore[attr-defined]
 
-    async def async_call_api(self, func, *args) -> bool:
-        """Call an API write function under the lock, re-logging in once if the session expired."""
+    async def async_call_api(self, func: Callable[..., bool], *args: Any) -> bool:
+        """Call an API write function under lock, re-logging in if session expired."""
         async with self.api_lock:
             result = await self.hass.async_add_executor_job(func, *args)
             if not result:
                 _LOGGER.info(
-                    "API call %s returned False, session likely expired — attempting re-login",
+                    "API call %s returned False, session may have expired — re-login",
                     func.__name__,
                 )
                 relogged = await self.hass.async_add_executor_job(


### PR DESCRIPTION
## Problem

Netgear switches expire web sessions over time. Write commands (`turn_on/off_poe_port`, `turn_on/off_leds`) were called directly via `async_add_executor_job` with no session recovery. Once the session expired, all switch commands silently failed — the entity state would appear to change momentarily then snap back on the next coordinator poll. The only workaround was restarting Home Assistant.

A secondary issue was that these write calls did not acquire `api_lock`, meaning they could race with the coordinator's 10-second polling cycle and corrupt the HTTP session.

## Fix

Introduces `async_call_api` on `HomeAssistantNetgearSwitch` which:
- Acquires `api_lock` to prevent concurrent access with the coordinator
- Detects a failed call (returns `False`) and attempts a single re-login via `get_login_cookie` before retrying
- Logs re-login attempts and outcomes at INFO level, and warns on re-login failure

All four switch write methods (PoE turn on/off, LED turn on/off) now route through this wrapper.

## Test plan

- [ ] Toggle a PoE port switch in Home Assistant immediately after startup — should work
- [ ] Leave HA running until the switch session expires, then toggle a PoE port — should re-login automatically and succeed (check logs for `Re-login successful` message)
- [ ] Confirm `called turn_on/off_poe_port ... successful=True` appears in logs after a re-login