### PR TITLE
chore: bump py-netgear-plus to 0.6.3, version to 0.7.11pre3

### DIFF
--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
   "requirements": [
     "lxml>=4.6.1",
-    "py-netgear-plus==v0.6.1"
+    "py-netgear-plus==0.6.3"
   ],
   "ssdp": [
     {

--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -19,5 +19,5 @@
       "deviceType": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
     }
   ],
-  "version": "0.7.11pre2"
+  "version": "0.7.11pre3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 colorlog==6.10.1
 homeassistant>=2024.12.5
 lxml>=4.6.1
-py-netgear-plus==v0.4.7
+py-netgear-plus==0.6.3
 pip>=21.3.1
 ruff==0.15.10


### PR DESCRIPTION
## Summary

- `manifest.json`: `py-netgear-plus==v0.6.1` → `0.6.3`, version `0.7.11pre2` → `0.7.11pre3`
- `requirements.txt`: `py-netgear-plus==v0.4.7` → `0.6.3`

py-netgear-plus 0.6.3 includes a fix for `AttributeError` when `script[0].text` is `None` in `_is_authenticated` (foxey/py-netgear-plus#161), which caused instability reported in foxey/py-netgear-plus#160.

*— Ada, AI assistant acting on behalf of [@foxey](https://github.com/foxey)*