### PR TITLE
fix: distinguish session expiry from command failure in async_call_api

### DIFF
--- a/custom_components/netgear_plus/netgear_switch.py
+++ b/custom_components/netgear_plus/netgear_switch.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
-from py_netgear_plus import NetgearSwitchConnector
+from py_netgear_plus import LoginFailedError, NetgearSwitchConnector
 from py_netgear_plus import __version__ as api_version
 
 from .const import DOMAIN
@@ -95,24 +95,27 @@ class HomeAssistantNetgearSwitch:
             return await self.hass.async_add_executor_job(self.api.get_switch_infos)  # type: ignore[attr-defined]
 
     async def async_call_api(self, func: Callable[..., bool], *args: Any) -> bool:
-        """Call an API write function under lock, re-logging in if session expired."""
+        """Call an API write function under lock.
+
+        py-netgear-plus write methods already handle session expiry internally:
+        they catch NotLoggedInError, attempt re-login, and raise LoginFailedError
+        if re-login fails. A False return value means the command genuinely failed
+        (non-SUCCESS response), not a session issue.
+        """
         async with self.api_lock:
-            result = await self.hass.async_add_executor_job(func, *args)
-            if not result:
-                _LOGGER.info(
-                    "API call %s returned False, session may have expired — re-login",
+            try:
+                result = await self.hass.async_add_executor_job(func, *args)
+            except LoginFailedError:
+                _LOGGER.warning(
+                    "API call %s failed: session expired and re-login failed",
                     func.__name__,
                 )
-                relogged = await self.hass.async_add_executor_job(
-                    self.api.get_login_cookie
+                return False
+            if not result:
+                _LOGGER.warning(
+                    "API call %s returned False: command failed",
+                    func.__name__,
                 )
-                if relogged:
-                    _LOGGER.info("Re-login successful, retrying %s", func.__name__)
-                    result = await self.hass.async_add_executor_job(func, *args)
-                else:
-                    _LOGGER.warning(
-                        "Re-login failed, cannot complete API call %s", func.__name__
-                    )
             return result
 
 

--- a/custom_components/netgear_plus/netgear_switch.py
+++ b/custom_components/netgear_plus/netgear_switch.py
@@ -95,13 +95,7 @@ class HomeAssistantNetgearSwitch:
             return await self.hass.async_add_executor_job(self.api.get_switch_infos)  # type: ignore[attr-defined]
 
     async def async_call_api(self, func: Callable[..., bool], *args: Any) -> bool:
-        """Call an API write function under lock.
-
-        py-netgear-plus write methods already handle session expiry internally:
-        they catch NotLoggedInError, attempt re-login, and raise LoginFailedError
-        if re-login fails. A False return value means the command genuinely failed
-        (non-SUCCESS response), not a session issue.
-        """
+        """Call an API write function under lock."""
         async with self.api_lock:
             try:
                 result = await self.hass.async_add_executor_job(func, *args)


### PR DESCRIPTION
## Summary

- Removes the retry-on-`False` logic from `async_call_api` in `netgear_switch.py`
- Adds `LoginFailedError` import from `py_netgear_plus` and catches it instead
- Logs genuine command failures (non-SUCCESS response) as warnings, distinct from session expiry

## Background

`py-netgear-plus` write methods (`switch_poe_port`, `switch_leds`, `switch_port`) already handle session expiry internally: they catch `NotLoggedInError`, attempt re-login, and raise `LoginFailedError` if re-login fails. A `False` return value from these methods means the command itself genuinely failed (non-SUCCESS HTTP response), **not** a session issue.

The previous `async_call_api` implementation incorrectly assumed `False` indicated session expiry and triggered a redundant re-login + retry. This masked genuine failures and could cause write commands (PoE toggle, LED switch, port on/off) to be executed twice.

Closes #215

## Test plan

- [ ] Toggle a PoE port on/off — verify it works normally (happy path)
- [ ] Simulate a command failure (e.g., send to unsupported port) — verify a single `WARNING` log appears, no retry
- [ ] Simulate session expiry (invalidate cookie) — verify `LoginFailedError` is caught and logged as `WARNING`, no crash

---

*— Ada, AI assistant acting on behalf of [@foxey](https://github.com/foxey)*