### PR TITLE
fix: catch SwitchModelNotDetectedError in SSDP discovery flow

### DIFF
--- a/custom_components/netgear_plus/config_flow.py
+++ b/custom_components/netgear_plus/config_flow.py
@@ -19,6 +19,8 @@ from homeassistant.util.network import is_ipv4_address
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigFlowResult
 
+from py_netgear_plus import SwitchModelNotDetectedError
+
 from .const import DEFAULT_CONF_TIMEOUT, DEFAULT_HOST, DOMAIN
 from .errors import CannotLoginError
 from .netgear_switch import get_api
@@ -135,6 +137,8 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 get_api,
                 updated_data[CONF_HOST],  # type: ignore[arg-type]
             )
+        except SwitchModelNotDetectedError:
+            return self.async_abort(reason="switch_not_detected")
         except requests.exceptions.ConnectTimeout:
             errors["base"] = "timeout"
         except NotImplementedError:

--- a/custom_components/netgear_plus/config_flow.py
+++ b/custom_components/netgear_plus/config_flow.py
@@ -195,4 +195,3 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             title=name,
             data=config_data,
         )
-

--- a/custom_components/netgear_plus/config_flow.py
+++ b/custom_components/netgear_plus/config_flow.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigFlowResult
 
 from py_netgear_plus import SwitchModelNotDetectedError
-
 from .const import DEFAULT_CONF_TIMEOUT, DEFAULT_HOST, DOMAIN
 from .errors import CannotLoginError
 from .netgear_switch import get_api
@@ -196,3 +195,4 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             title=name,
             data=config_data,
         )
+

--- a/custom_components/netgear_plus/config_flow.py
+++ b/custom_components/netgear_plus/config_flow.py
@@ -15,11 +15,11 @@ if TYPE_CHECKING:
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_TIMEOUT
 from homeassistant.core import callback
 from homeassistant.util.network import is_ipv4_address
+from py_netgear_plus import SwitchModelNotDetectedError
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigFlowResult
 
-from py_netgear_plus import SwitchModelNotDetectedError
 from .const import DEFAULT_CONF_TIMEOUT, DEFAULT_HOST, DOMAIN
 from .errors import CannotLoginError
 from .netgear_switch import get_api

--- a/custom_components/netgear_plus/strings.json
+++ b/custom_components/netgear_plus/strings.json
@@ -13,7 +13,8 @@
       "config": "Connection or login error: please check your configuration"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "switch_not_detected": "Switch model could not be detected during SSDP discovery"
     }
   }
 }

--- a/custom_components/netgear_plus/translations/en.json
+++ b/custom_components/netgear_plus/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "switch_not_detected": "Switch model could not be detected during SSDP discovery"
         },
         "error": {
             "config": "Connection or login error: please check your configuration"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ colorlog==6.10.1
 homeassistant>=2024.12.5
 lxml>=6.1.1
 py-netgear-plus==0.6.3
-pip>=26.1.1
-ruff==0.15.14
+pip>=26.1.2
+ruff==0.15.16


### PR DESCRIPTION
Fixes #177

Catch `SwitchModelNotDetectedError` in `async_step_ssdp` and abort with `reason="switch_not_detected"` instead of letting the exception propagate unhandled.

Also adds the corresponding abort message to `strings.json` and `translations/en.json`.

*— Ada, AI assistant acting on behalf of [@foxey](https://github.com/foxey)*