### PR TITLE
Improve NETGEAR Plus SSDP discovery flow handling

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "s114646/ha-netgear-plus",
+    "name": "ckarrie/ha-netgear-plus",
     "image": "mcr.microsoft.com/devcontainers/python:dev-3.13",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ckarrie/ha-netgear-plus",
+    "name": "s114646/ha-netgear-plus",
     "image": "mcr.microsoft.com/devcontainers/python:dev-3.13",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [

--- a/custom_components/netgear_plus/config_flow.py
+++ b/custom_components/netgear_plus/config_flow.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_TIMEOUT
 from homeassistant.core import callback
 from homeassistant.util.network import is_ipv4_address
-from py_netgear_plus import SwitchModelNotDetectedError
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigFlowResult
@@ -118,7 +117,6 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Initialize flow from ssdp."""
         updated_data: dict[str, str | int | bool] = {}
-        errors: dict[str, str] = {}
 
         device_url = urlparse(discovery_info.ssdp_location)
         if hostname := device_url.hostname:
@@ -130,24 +128,9 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         _LOGGER.debug("Netgear ssdp discovery info: %s", discovery_info)
 
-        # Open connection to get unique id
-        try:
-            api = await self.hass.async_add_executor_job(
-                get_api,
-                updated_data[CONF_HOST],  # type: ignore[arg-type]
-            )
-        except SwitchModelNotDetectedError:
-            return self.async_abort(reason="switch_not_detected")
-        except requests.exceptions.ConnectTimeout:
-            errors["base"] = "timeout"
-        except NotImplementedError:
-            errors["base"] = "not_implemented_error"
+        self._async_abort_entries_match({CONF_HOST: hostname})
 
-        unique_id = await self.hass.async_add_executor_job(api.get_unique_id)
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured(updates=updated_data)
-
-        self.placeholders.update(updated_data)  # type: ignore[arg-type]
+        self.placeholders.update(updated_data)
         self.discovered = True
 
         return await self.async_step_user()

--- a/custom_components/netgear_plus/config_flow.py
+++ b/custom_components/netgear_plus/config_flow.py
@@ -128,8 +128,11 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         _LOGGER.debug("Netgear ssdp discovery info: %s", discovery_info)
 
+        await self.async_set_unique_id(f"{DOMAIN}_{hostname}")
+        self._abort_if_unique_id_configured()
         self._async_abort_entries_match({CONF_HOST: hostname})
 
+        self.context["title_placeholders"] = {CONF_HOST: hostname}
         self.placeholders.update(updated_data)
         self.discovered = True
 

--- a/custom_components/netgear_plus/config_flow.py
+++ b/custom_components/netgear_plus/config_flow.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_TIMEOUT
 from homeassistant.core import callback
 from homeassistant.util.network import is_ipv4_address
+from py_netgear_plus import SwitchModelNotDetectedError
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigFlowResult
@@ -155,6 +156,8 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             api = await self.hass.async_add_executor_job(get_api, host, password)
         except CannotLoginError:
             errors["base"] = "config"
+        except SwitchModelNotDetectedError:
+            errors["base"] = "switch_not_detected"
         except requests.exceptions.ConnectTimeout:
             errors["base"] = "timeout"
         except NotImplementedError:

--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
   "requirements": [
     "lxml>=6.1.0",
-    "py-netgear-plus @ git+https://github.com/S1146468/py-netgear-plus.git@v1"
+    "py-netgear-plus @ git+https://github.com/S1146468/py-netgear-plus.git@main"
   ],
   "ssdp": [
     {

--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
   "requirements": [
     "lxml>=6.1.0",
-    "py-netgear-plus @ git+https://github.com/S1146468/py-netgear-plus.git@v1"
+    "py-netgear-plus==0.6.4"
   ],
   "ssdp": [
     {

--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
   "requirements": [
     "lxml>=6.1.0",
-    "py-netgear-plus @ git+https://github.com/S1146468/py-netgear-plus.git@main"
+    "py-netgear-plus @ git+https://github.com/S1146468/py-netgear-plus.git@msjsondetect"
   ],
   "ssdp": [
     {

--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
   "requirements": [
     "lxml>=6.1.0",
-    "py-netgear-plus==0.6.4"
+    "py-netgear-plus @ git+https://github.com/S1146468/py-netgear-plus.git@v1"
   ],
   "ssdp": [
     {

--- a/custom_components/netgear_plus/strings.json
+++ b/custom_components/netgear_plus/strings.json
@@ -14,6 +14,7 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "Discovery is already in progress",
       "switch_not_detected": "Switch model could not be detected during SSDP discovery"
     }
   }

--- a/custom_components/netgear_plus/strings.json
+++ b/custom_components/netgear_plus/strings.json
@@ -10,7 +10,8 @@
       }
     },
     "error": {
-      "config": "Connection or login error: please check your configuration"
+      "config": "Connection or login error: please check your configuration",
+      "switch_not_detected": "Switch model could not be detected; check the password and switch support"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Netgear Plus",
-  "filename": "netgear_plus.zip",
+  "filename": "ha-netgear-plus-1.0.zip",
   "homeassistant": "2024.9.0",
   "hide_default_branch": true,
   "render_readme": true,

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Netgear Plus",
-  "filename": "ha-netgear-plus-1.0.zip",
+  "filename": "netgear_plus.zip",
   "homeassistant": "2024.9.0",
   "hide_default_branch": true,
   "render_readme": true,


### PR DESCRIPTION
# PR context: `ckarrie/ha-netgear-plus`

Related to foxey/py-netgear-plus#177

## Summary

This PR fixes the Home Assistant integration behavior around SSDP discovery and config-flow error handling for NETGEAR Plus switches.

It does not replace the library-level model detection fix in `py-netgear-plus`. Instead, it ensures Home Assistant does not call the library at the wrong time and does not crash when model detection fails.

## Problem

The integration previously called `get_api(host)` during SSDP discovery, before the user entered a password.

That was a problem for MS305E/MS308E switches because they use the JSON REST API and may require authentication before model detection works.

The result was:

- SSDP discovery could find the switch.
- The integration tried unauthenticated model detection immediately.
- `py-netgear-plus` could raise `SwitchModelNotDetectedError`.
- Discovery failed before the user could submit credentials.

After changing SSDP discovery to avoid unauthenticated model detection, another UX problem showed up: repeated SSDP announcements could create duplicate discovery cards, and model detection errors during the user step could bubble up as an aiohttp/Home Assistant traceback.

## Changes

This PR changes the HA config flow so that:

- SSDP discovery only extracts and pre-fills the discovered host.
- SSDP discovery no longer calls `get_api(host)` without credentials.
- A temporary host-based unique ID is used to reduce duplicate SSDP discovery flows.
- Existing entries are matched by host during discovery.
- Actual model detection is deferred to the user step, after the password is submitted.
- `SwitchModelNotDetectedError` is caught during the user step and shown as a normal form error.

## Why this belongs in `ha-netgear-plus`

`ha-netgear-plus` owns the Home Assistant discovery/config-flow behavior.

The integration should not attempt unauthenticated model detection during SSDP discovery. SSDP should only identify that a candidate device exists and open the setup flow. The library can then perform authenticated model detection once the user submits the password.

## Relationship to the `py-netgear-plus` PR

This PR is complementary to the library fix.

- The `py-netgear-plus` PR fixes the underlying MS-series JSON REST model detection.
- This `ha-netgear-plus` PR fixes how Home Assistant calls the library and handles failures.

For that reason, this PR should reference the issue but not close it:

```md
Related to foxey/py-netgear-plus#177
```

The `py-netgear-plus` PR should be the one that closes the issue:

```md
Fixes foxey/py-netgear-plus#177
```

## Validation

Validated with the Home Assistant integration and the `py-netgear-plus` fix branch.

Before:

- SSDP discovery could fail before credentials were entered.
- Duplicate discovery cards could appear.
- Submitting the password could produce an aiohttp traceback if model detection failed.

After:

- SSDP discovery opens the Add flow.
- Duplicate discovery flows are reduced.
- Model detection happens after the password is submitted.
- If model detection still fails, the user sees a normal form error instead of a Home Assistant server traceback.
