### PR TITLE
Resolve host names to IP in config flow, with local-domain fallback

### DIFF
--- a/custom_components/netgear_plus/config_flow.py
+++ b/custom_components/netgear_plus/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import socket
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
 
@@ -21,10 +22,34 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigFlowResult
 
 from .const import DEFAULT_CONF_TIMEOUT, DEFAULT_HOST, DOMAIN
-from .errors import CannotLoginError
+from .errors import CannotLoginError, CannotResolveError
 from .netgear_switch import get_api
 
 _LOGGER = logging.getLogger(__name__)
+
+# Home Assistant OS has no local DNS search domain, so a bare single-label
+# host name (e.g. "dining-switch-3") does not resolve. Try these suffixes.
+LOCAL_DOMAIN_SUFFIXES = (".home", ".lan")
+
+
+def _resolve_host(host: str) -> str:
+    """Resolve a host name to an IPv4 address.
+
+    Returns IP addresses unchanged. For a bare single-label name that the
+    system resolver cannot answer, retry with common local domain suffixes
+    appended. Raises CannotResolveError if nothing resolves.
+    """
+    if is_ipv4_address(host):
+        return host
+    candidates = [host]
+    if "." not in host:
+        candidates += [f"{host}{suffix}" for suffix in LOCAL_DOMAIN_SUFFIXES]
+    for candidate in candidates:
+        try:
+            return socket.gethostbyname(candidate)
+        except OSError:  # socket.gaierror is a subclass of OSError
+            continue
+    raise CannotResolveError(host)
 
 
 def _discovery_schema_with_defaults(discovery_info: dict[str, Any]) -> vol.Schema:
@@ -164,6 +189,15 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         host = user_input.get(CONF_HOST, self.placeholders[CONF_HOST])
         password = user_input[CONF_PASSWORD]
 
+        # Resolve host names to an IP so a bare name (no search domain on
+        # Home Assistant OS) works and connection errors are reported clearly.
+        try:
+            host = await self.hass.async_add_executor_job(_resolve_host, host)
+        except CannotResolveError:
+            return await self._show_setup_form(
+                user_input, {"base": "cannot_resolve"}
+            )
+
         # Open connection and check authentication
         try:
             api = await self.hass.async_add_executor_job(get_api, host, password)
@@ -171,6 +205,8 @@ class NetgearFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "config"
         except requests.exceptions.ConnectTimeout:
             errors["base"] = "timeout"
+        except (requests.exceptions.ConnectionError, OSError):
+            errors["base"] = "cannot_connect"
         except NotImplementedError:
             errors["base"] = "not_implemented_error"
 

--- a/custom_components/netgear_plus/errors.py
+++ b/custom_components/netgear_plus/errors.py
@@ -5,3 +5,7 @@ from homeassistant.exceptions import HomeAssistantError
 
 class CannotLoginError(HomeAssistantError):
     """Unable to login to the router."""
+
+
+class CannotResolveError(HomeAssistantError):
+    """Unable to resolve the configured host name to an IP address."""

--- a/custom_components/netgear_plus/strings.json
+++ b/custom_components/netgear_plus/strings.json
@@ -10,7 +10,9 @@
       }
     },
     "error": {
-      "config": "Connection or login error: please check your configuration"
+      "config": "Connection or login error: please check your configuration",
+      "cannot_resolve": "Cannot resolve host name. Use the switch's IP address, or a fully-qualified name (e.g. host.home).",
+      "cannot_connect": "Cannot connect to the switch. Check the address and that it is reachable."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/custom_components/netgear_plus/translations/en.json
+++ b/custom_components/netgear_plus/translations/en.json
@@ -5,7 +5,9 @@
             "switch_not_detected": "Switch model could not be detected during SSDP discovery"
         },
         "error": {
-            "config": "Connection or login error: please check your configuration"
+            "config": "Connection or login error: please check your configuration",
+            "cannot_resolve": "Cannot resolve host name. Use the switch's IP address, or a fully-qualified name (e.g. host.home).",
+            "cannot_connect": "Cannot connect to the switch. Check the address and that it is reachable."
         },
         "step": {
             "user": {


### PR DESCRIPTION
## Summary

Entering a bare host name (e.g. `dining-switch-3`) in the config flow failed with a generic **Unknown error occurred**, because Home Assistant OS has no local DNS search domain (`/etc/resolv.conf` only has `search local.hass.io`), so single-label names don't resolve — and the resulting exception wasn't handled.

This PR:
- Resolves the configured host to an IPv4 address before connecting (IP addresses pass through unchanged).
- For a bare single-label name, retries with common local suffixes (`.home`, `.lan`).
- Adds `cannot_resolve` / `cannot_connect` error strings so failures are reported clearly instead of an unhandled exception.

## Testing

- Verified on a live HAOS install: bare `dining-switch-3` previously failed; with this change it resolves via the `.home` fallback and the switch (JGS516PE) connects.
- `python -m py_compile` clean; JSON translations validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEJWytT9EPQykxX4Xf2Ch8