### PR TITLE
Add GS308EP port configuration supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@
 
 Due to the renaming of the integration and the repository, HACS gets confused and installs the new version next to the old one instead of replacing the old version. Please remove the old version first before installing the latest release.
 
+## Configuration Features
+
+Supported models (including GS308EP) support:
+
+- Port Name editing
+- Port Speed configuration
+- Flow Control
+- Ingress Rate Limit
+- Egress Rate Limit
+- PoE enable/disable
+- PoE power cycle
+- Clear Port Statistics
+
 ## What it does
 
 Grabs statistical network data from [supported NETGEAR Switches](#supported-and-tested-netgear-modelsproducts-and-firmwares) from the

--- a/custom_components/netgear_plus/const.py
+++ b/custom_components/netgear_plus/const.py
@@ -7,7 +7,14 @@ from py_netgear_plus import models
 
 DOMAIN = "netgear_plus"
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH, Platform.BUTTON]
+PLATFORMS = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.BUTTON,
+    Platform.SELECT,
+    Platform.TEXT,
+]
 
 DEFAULT_NAME = "Netgear Plus Switch"
 SCAN_INTERVAL = 10

--- a/custom_components/netgear_plus/manifest.json
+++ b/custom_components/netgear_plus/manifest.json
@@ -2,16 +2,17 @@
   "domain": "netgear_plus",
   "name": "NETGEAR Plus",
   "codeowners": [
+    "@bakernigel",
     "@ckarrie",
     "@foxey"
   ],
   "config_flow": true,
-  "documentation": "https://github.com/ckarrie/ha-netgear-plus/blob/main/README.md",
+  "documentation": "https://github.com/bakernigel/ha-netgear-plus/blob/main/README.md",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/ckarrie/ha-netgear-plus/issues",
+  "issue_tracker": "https://github.com/bakernigel/ha-netgear-plus/issues",
   "requirements": [
     "lxml>=6.1.0",
-    "py-netgear-plus==0.6.4"
+    "py-netgear-plus @ git+https://github.com/bakernigel/py-netgear-plus.git@v1.0.0"
   ],
   "ssdp": [
     {
@@ -19,5 +20,5 @@
       "deviceType": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"
     }
   ],
-  "version": "0.7.11"
+  "version": "1.0.0"
 }

--- a/custom_components/netgear_plus/netgear_switch.py
+++ b/custom_components/netgear_plus/netgear_switch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from functools import partial
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any
 
@@ -90,15 +91,32 @@ class HomeAssistantNetgearSwitch:
         return True
 
     async def async_get_switch_infos(self) -> dict[str, Any] | None:
-        """Get switch information asynchronously."""
+        """Get switch information and editable port settings asynchronously."""
         async with self.api_lock:
-            return await self.hass.async_add_executor_job(self.api.get_switch_infos)  # type: ignore[attr-defined]
+            switch_infos = await self.hass.async_add_executor_job(
+                self.api.get_switch_infos
+            )  # type: ignore[attr-defined]
+            if switch_infos is None:
+                return None
 
-    async def async_call_api(self, func: Callable[..., bool], *args: Any) -> bool:
+            if self.api.switch_model.MODEL_NAME == "GS308EP":  # type: ignore[union-attr]
+                port_settings = await self.hass.async_add_executor_job(
+                    self.api.get_port_settings
+                )  # type: ignore[attr-defined]
+                for port, settings in port_settings.items():
+                    for setting, value in settings.items():
+                        switch_infos[f"port_{port}_setting_{setting}"] = value
+
+            return switch_infos
+
+    async def async_call_api(
+        self, func: Callable[..., bool], *args: Any, **kwargs: Any
+    ) -> bool:
         """Call an API write function under lock."""
         async with self.api_lock:
             try:
-                result = await self.hass.async_add_executor_job(func, *args)
+                call = partial(func, *args, **kwargs)
+                result = await self.hass.async_add_executor_job(call)
             except LoginFailedError:
                 _LOGGER.warning(
                     "API call %s failed: session expired and re-login failed",

--- a/custom_components/netgear_plus/select.py
+++ b/custom_components/netgear_plus/select.py
@@ -1,0 +1,227 @@
+"""Editable Netgear Plus port settings select entities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from py_netgear_plus import (
+    PORT_SPEED_100_FULL,
+    PORT_SPEED_100_HALF,
+    PORT_SPEED_10_FULL,
+    PORT_SPEED_10_HALF,
+    PORT_SPEED_AUTO,
+    PORT_SPEED_DISABLED,
+)
+
+from . import NetgearSwitchConfigEntry
+from .netgear_switch import HomeAssistantNetgearSwitch, NetgearAPICoordinatorEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+SPEED_TO_OPTION = {
+    PORT_SPEED_AUTO: "Auto",
+    PORT_SPEED_DISABLED: "Disabled",
+    PORT_SPEED_10_HALF: "10 Mbps half duplex",
+    PORT_SPEED_10_FULL: "10 Mbps full duplex",
+    PORT_SPEED_100_HALF: "100 Mbps half duplex",
+    PORT_SPEED_100_FULL: "100 Mbps full duplex",
+}
+OPTION_TO_SPEED = {option: speed for speed, option in SPEED_TO_OPTION.items()}
+
+
+# GS308EP rate-limit values are dropdown option codes used by the switch.
+RATE_TO_OPTION = {
+    1: "No Limit",
+    2: "512 Kbit/s",
+    3: "1 Mbit/s",
+    4: "2 Mbit/s",
+    5: "4 Mbit/s",
+    6: "8 Mbit/s",
+    7: "16 Mbit/s",
+    8: "32 Mbit/s",
+    9: "64 Mbit/s",
+    10: "128 Mbit/s",
+    11: "256 Mbit/s",
+    12: "512 Mbit/s",
+}
+OPTION_TO_RATE = {option: rate for rate, option in RATE_TO_OPTION.items()}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: NetgearSwitchConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up editable port speed selects."""
+    del hass
+    gs_switch = config_entry.runtime_data.gs_switch
+    coordinator = config_entry.runtime_data.coordinator_switch_infos
+
+    if (
+        not gs_switch.api
+        or not gs_switch.api.ports
+        or gs_switch.api.switch_model.MODEL_NAME != "GS308EP"
+    ):
+        return
+
+    entities: list[SelectEntity] = []
+    for port in range(1, gs_switch.api.ports + 1):
+        entities.extend(
+            (
+                NetgearPortSpeedSelectEntity(coordinator, gs_switch, port),
+                NetgearPortRateLimitSelectEntity(
+                    coordinator,
+                    gs_switch,
+                    port,
+                    direction="ingress",
+                ),
+                NetgearPortRateLimitSelectEntity(
+                    coordinator,
+                    gs_switch,
+                    port,
+                    direction="egress",
+                ),
+            )
+        )
+
+    async_add_entities(entities)
+
+
+class NetgearPortSpeedSelectEntity(NetgearAPICoordinatorEntity, SelectEntity):
+    """Select entity for a port's configured speed and enabled state."""
+
+    _attr_options = list(OPTION_TO_SPEED)
+    _attr_icon = "mdi:ethernet"
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        hub: HomeAssistantNetgearSwitch,
+        port_nr: int,
+    ) -> None:
+        """Initialize the port speed select."""
+        super().__init__(coordinator, hub)
+        self.hub = hub
+        self.port_nr = port_nr
+        self._unique_id = f"{hub.unique_id}-port_{port_nr}_speed"
+        self._attr_current_option = None
+        self.async_update_device()
+
+    @property
+    def name(self) -> str:
+        """Return the entity name, including the configured port description."""
+        data = self.coordinator.data or {}
+        description = str(
+            data.get(f"port_{self.port_nr}_setting_name")
+            or data.get(f"port_{self.port_nr}_description")
+            or ""
+        ).strip()
+        base = f"Port {self.port_nr} Speed"
+        return f"{base} ({description})" if description else base
+
+    @callback
+    def async_update_device(self) -> None:
+        """Update the selected option from coordinator data."""
+        data = self.coordinator.data or {}
+        speed = data.get(f"port_{self.port_nr}_setting_speed")
+        try:
+            speed = int(speed)
+        except (TypeError, ValueError):
+            self._attr_current_option = None
+            return
+        self._attr_current_option = SPEED_TO_OPTION.get(speed)
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the configured port speed."""
+        speed = OPTION_TO_SPEED.get(option)
+        if speed is None:
+            raise HomeAssistantError(f"Unsupported port speed option: {option}")
+
+        successful = await self.hub.async_call_api(
+            self.hub.api.set_port_settings,
+            self.port_nr,
+            speed=speed,
+        )
+        if not successful:
+            raise HomeAssistantError(
+                f"Changing speed for port {self.port_nr} to {option} failed"
+            )
+
+        self._attr_current_option = option
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+
+class NetgearPortRateLimitSelectEntity(NetgearAPICoordinatorEntity, SelectEntity):
+    """Select entity for a GS308EP port ingress or egress rate limit."""
+
+    _attr_options = list(OPTION_TO_RATE)
+    _attr_icon = "mdi:speedometer"
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        hub: HomeAssistantNetgearSwitch,
+        port_nr: int,
+        *,
+        direction: str,
+    ) -> None:
+        """Initialize a port rate-limit select."""
+        if direction not in {"ingress", "egress"}:
+            raise ValueError(f"Unsupported rate-limit direction: {direction}")
+
+        super().__init__(coordinator, hub)
+        self.hub = hub
+        self.port_nr = port_nr
+        self.direction = direction
+        self._unique_id = (
+            f"{hub.unique_id}-port_{port_nr}_{direction}_rate_limit"
+        )
+        label = "In Rate Limit" if direction == "ingress" else "Out Rate Limit"
+        self._name = f"Port {port_nr} {label}"
+        self._attr_current_option = None
+        self.async_update_device()
+
+    @callback
+    def async_update_device(self) -> None:
+        """Update the selected rate limit from coordinator data."""
+        data = self.coordinator.data or {}
+        key = f"port_{self.port_nr}_setting_{self.direction}_rate"
+        rate = data.get(key)
+
+        try:
+            rate = int(rate)
+        except (TypeError, ValueError):
+            self._attr_current_option = None
+            return
+
+        self._attr_current_option = RATE_TO_OPTION.get(rate)
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the configured port rate limit."""
+        rate = OPTION_TO_RATE.get(option)
+        if rate is None:
+            raise HomeAssistantError(f"Unsupported rate-limit option: {option}")
+
+        kwargs = {f"{self.direction}_rate": rate}
+        successful = await self.hub.async_call_api(
+            self.hub.api.set_port_settings,
+            self.port_nr,
+            **kwargs,
+        )
+        if not successful:
+            label = "in" if self.direction == "ingress" else "out"
+            raise HomeAssistantError(
+                f"Changing {label} rate limit for port {self.port_nr} "
+                f"to {option} failed"
+            )
+
+        self._attr_current_option = option
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/netgear_plus/switch.py
+++ b/custom_components/netgear_plus/switch.py
@@ -3,8 +3,11 @@
 import logging
 
 from homeassistant.components.switch import SwitchDeviceClass
-from homeassistant.core import HomeAssistant
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import NetgearSwitchConfigEntry
 from .netgear_entities import (
@@ -13,6 +16,7 @@ from .netgear_entities import (
     NetgearPOESwitchEntity,
     NetgearPortSwitchEntity,
 )
+from .netgear_switch import HomeAssistantNetgearSwitch, NetgearAPICoordinatorEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,9 +52,31 @@ async def async_setup_entry(
 
             entities.append(switch_entity)
 
-    if gs_switch.api and gs_switch.api.ports:
+    if (
+        gs_switch.api
+        and gs_switch.api.ports
+        and gs_switch.api.switch_model.MODEL_NAME == "GS308EP"
+    ):
         _LOGGER.info(
-            "[switch.async_setup_entry] setting up Port switches for %s ports",
+            "[switch.async_setup_entry] setting up Flow Control switches for %s ports",
+            gs_switch.api.ports,
+        )
+        for port_nr in range(1, gs_switch.api.ports + 1):
+            entities.append(
+                NetgearPortFlowControlSwitchEntity(
+                    coordinator=coordinator_switch_infos,
+                    hub=gs_switch,
+                    port_nr=port_nr,
+                )
+            )
+
+    if (
+        gs_switch.api
+        and gs_switch.api.ports
+        and gs_switch.api.switch_model.MODEL_NAME != "GS308EP"
+    ):
+        _LOGGER.info(
+            "[switch.async_setup_entry] setting up legacy Port switches for %s ports",
             gs_switch.api.ports,
         )
         for port_nr in range(1, gs_switch.api.ports + 1):
@@ -84,3 +110,66 @@ async def async_setup_entry(
         entities.append(switch_entity)
 
     async_add_entities(entities)
+
+
+class NetgearPortFlowControlSwitchEntity(NetgearAPICoordinatorEntity, SwitchEntity):
+    """Switch entity for a GS308EP port's flow-control setting."""
+
+    _attr_icon = "mdi:swap-horizontal"
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        hub: HomeAssistantNetgearSwitch,
+        port_nr: int,
+    ) -> None:
+        """Initialize the port flow-control switch."""
+        super().__init__(coordinator, hub)
+        self.hub = hub
+        self.port_nr = port_nr
+        self._unique_id = f"{hub.unique_id}-port_{port_nr}_flow_control"
+        self._name = f"Port {port_nr} Flow Control"
+        self._attr_is_on = False
+        self.async_update_device()
+
+    @callback
+    def async_update_device(self) -> None:
+        """Update flow-control state from coordinator data."""
+        data = self.coordinator.data or {}
+        value = data.get(f"port_{self.port_nr}_setting_flow_control")
+
+        if isinstance(value, bool):
+            self._attr_is_on = value
+            return
+
+        try:
+            self._attr_is_on = int(value) == 1
+        except (TypeError, ValueError):
+            self._attr_is_on = False
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable flow control for this port."""
+        del kwargs
+        await self._async_set_flow_control(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable flow control for this port."""
+        del kwargs
+        await self._async_set_flow_control(False)
+
+    async def _async_set_flow_control(self, enabled: bool) -> None:
+        """Write the flow-control setting to the switch."""
+        successful = await self.hub.async_call_api(
+            self.hub.api.set_port_settings,
+            self.port_nr,
+            flow_control=enabled,
+        )
+        if not successful:
+            state = "enabling" if enabled else "disabling"
+            raise HomeAssistantError(
+                f"{state.capitalize()} flow control for port {self.port_nr} failed"
+            )
+
+        self._attr_is_on = enabled
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/netgear_plus/text.py
+++ b/custom_components/netgear_plus/text.py
@@ -1,0 +1,77 @@
+"""Editable Netgear Plus port name text entities."""
+
+from __future__ import annotations
+
+from homeassistant.components.text import TextEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from . import NetgearSwitchConfigEntry
+from .netgear_switch import HomeAssistantNetgearSwitch, NetgearAPICoordinatorEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: NetgearSwitchConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up editable port name text entities."""
+    del hass
+    gs_switch = config_entry.runtime_data.gs_switch
+    coordinator = config_entry.runtime_data.coordinator_switch_infos
+
+    if (
+        not gs_switch.api
+        or not gs_switch.api.ports
+        or gs_switch.api.switch_model.MODEL_NAME != "GS308EP"
+    ):
+        return
+
+    async_add_entities(
+        NetgearPortNameTextEntity(coordinator, gs_switch, port)
+        for port in range(1, gs_switch.api.ports + 1)
+    )
+
+
+class NetgearPortNameTextEntity(NetgearAPICoordinatorEntity, TextEntity):
+    """Text entity for a port's configured name."""
+
+    _attr_icon = "mdi:rename"
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        hub: HomeAssistantNetgearSwitch,
+        port_nr: int,
+    ) -> None:
+        """Initialize the port name text entity."""
+        super().__init__(coordinator, hub)
+        self.hub = hub
+        self.port_nr = port_nr
+        self._unique_id = f"{hub.unique_id}-port_{port_nr}_name"
+        self._name = f"Port {port_nr} Port Name"
+        self._attr_native_value = ""
+        self.async_update_device()
+
+    @callback
+    def async_update_device(self) -> None:
+        """Update the configured port name from coordinator data."""
+        data = self.coordinator.data or {}
+        value = data.get(f"port_{self.port_nr}_setting_name")
+        self._attr_native_value = "" if value is None else str(value)
+
+    async def async_set_value(self, value: str) -> None:
+        """Set the configured port name."""
+        successful = await self.hub.async_call_api(
+            self.hub.api.set_port_name,
+            self.port_nr,
+            value,
+        )
+        if not successful:
+            raise HomeAssistantError(f"Renaming port {self.port_nr} failed")
+
+        self._attr_native_value = value
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
Requires updated py-netgear-plus.
See PR: 
https://github.com/foxey/py-netgear-plus/pull/198
or
https://github.com/bakernigel/py-netgear-plus.git@v1.0.0"



## Summary

This PR adds support for configuring GS308EP switch ports directly from Home Assistant.

### New entities
The new configuration entities are only created when the connected switch reports itself as a GS308EP, so there is no behavioral change for existing supported models.

#### Text

- Port Name

#### Select

- Port Speed
- In Rate Limit
- Out Rate Limit

#### Switch

- Flow Control

### Improvements

- Port settings are now exposed through native Home Assistant entities.
- Configuration changes are written back to the switch immediately.
- Coordinator refreshes automatically after successful updates.
- Entity naming has been standardized so Home Assistant groups entities neatly by port.

Example:

Port 1
- Port Name
- Speed
- Flow Control
- In Rate Limit
- Out Rate Limit
- PoE
- Statistics

### Library changes

Requires:

py-netgear-plus v1.0.0

### Supported hardware

Currently enabled only for:

- GS308EP

No behaviour changes for other supported switch models.

## Testing

Tested on a physical GS308EP.

Verified:

- ✓ Read Port Name
- ✓ Write Port Name
- ✓ Read Port Speed
- ✓ Write Port Speed
- ✓ Read Flow Control
- ✓ Write Flow Control
- ✓ Read In Rate Limit
- ✓ Write In Rate Limit
- ✓ Read Out Rate Limit
- ✓ Write Out Rate Limit
- ✓ Existing PoE functionality unchanged
- ✓ Existing statistics unchanged